### PR TITLE
Debug Chrome DevTools timeout issue

### DIFF
--- a/MVAEndlessRunner/modules/endlessrunner/units/coin.js
+++ b/MVAEndlessRunner/modules/endlessrunner/units/coin.js
@@ -20,9 +20,8 @@ define([
         this.drawCircle(-5, -5, 15);
         this.endFill();
 
-        game.physics.arcade.enable(this);
-        this.body.setCircle(15);
-        this.body.checkCollision = true;
+        // Physics will be enabled in update() after the object is added to the game
+        this.physicsInitialized = false;
 
         gameScene = theGame;
     }
@@ -31,10 +30,22 @@ define([
     Coin.prototype.constructor = Coin;
 
     Coin.prototype.update = function () {
+        // Initialize physics after the object has been added to the game
+        if (!this.physicsInitialized) {
+            this.game.physics.arcade.enable(this);
+            if (this.body) {
+                this.body.setCircle(15);
+                this.body.checkCollision = true;
+                this.physicsInitialized = true;
+            }
+        }
+
         calculateCoinSpeed();
 
         // Check for collection (overlap with player)
-        this.game.physics.arcade.overlap(this, gameScene.getPlayer(), this.collect, null, this);
+        if (this.physicsInitialized) {
+            this.game.physics.arcade.overlap(this, gameScene.getPlayer(), this.collect, null, this);
+        }
 
         this.position.x -= coinSpeed;
         if (this.position.x < -50) {


### PR DESCRIPTION
The Coin class was trying to set up physics in the constructor before the Graphics object was added to the game world, causing this.body to be undefined and resulting in a "Cannot read properties of undefined (reading 'setCircle')" error after 8 meters of gameplay.

Solution: Moved physics initialization to the update() method where it's executed once after the object is added to the game, preventing the undefined body error.

Fixes issue reported in coin.js:24