### PR TITLE
Still the S

### DIFF
--- a/MVAEndlessRunner/modules/endlessrunner/runtime.js
+++ b/MVAEndlessRunner/modules/endlessrunner/runtime.js
@@ -3,7 +3,8 @@
 requirejs.config({
     paths: {
         Phaser: "vendor/phaser"
-    }
+    },
+    urlArgs: "bust=" + (new Date()).getTime()
 });
 
 


### PR DESCRIPTION
The browser was caching old versions of the JavaScript files, causing the physics initialization error to persist even after the fix was applied. Adding urlArgs to requirejs config forces the browser to reload all modules with a timestamp parameter.